### PR TITLE
[BUGFIX] Fix SQL GRANT syntax in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_script:
   echo;
   echo "Creating the database and importing the database schema";
   mysql -e "CREATE DATABASE ${PHPLIST_DATABASE_NAME};";
-  mysql -u root -e "GRANT ALL ON ${PHPLIST_DATABASE_NAME}.* TO ${PHPLIST_DATABASE_USER}@''%'';";
+  mysql -u root -e "GRANT ALL ON ${PHPLIST_DATABASE_NAME}.* TO '${PHPLIST_DATABASE_USER}'@'%';";
   mysql ${PHPLIST_DATABASE_NAME} < Database/Schema.sql;
 
 script:


### PR DESCRIPTION
There was a double set of single quotes for the host name,
and the user name was not quoted at all.