### PR TITLE
[FEATURE] Repository.remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Repository.remove (#278)
 - Interface for domain models (#274)
 - Trait for database tests and abstract web test (#264)
 - Repository methods for querying subscriptions (#253)

--- a/src/Domain/Repository/AbstractRepository.php
+++ b/src/Domain/Repository/AbstractRepository.php
@@ -28,4 +28,20 @@ abstract class AbstractRepository extends EntityRepository
         $this->getEntityManager()->persist($model);
         $this->getEntityManager()->flush();
     }
+
+    /**
+     * Removes $model and flushes the entity manager change list.
+     *
+     * This method allows controllers to not depend on the entity manager, but only on the repositories instead,
+     * following the Law of Demeter.
+     *
+     * @param DomainModel $model
+     *
+     * @return void
+     */
+    public function remove(DomainModel $model)
+    {
+        $this->getEntityManager()->remove($model);
+        $this->getEntityManager()->flush();
+    }
 }

--- a/tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
+++ b/tests/Integration/Domain/Repository/Identity/AdministratorRepositoryTest.php
@@ -207,4 +207,23 @@ class AdministratorRepositoryTest extends TestCase
 
         static::assertSame($model, $this->subject->find($model->getId()));
     }
+
+    /**
+     * @test
+     */
+    public function removeRemovesModel()
+    {
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Administrator.csv');
+        $this->applyDatabaseChanges();
+
+        /** @var Administrator[] $allModels */
+        $allModels = $this->subject->findAll();
+        $numberOfModelsBeforeRemove = count($allModels);
+        $firstModel = $allModels[0];
+
+        $this->subject->remove($firstModel);
+
+        $numberOfModelsAfterRemove = count($this->subject->findAll());
+        static::assertSame(1, $numberOfModelsBeforeRemove - $numberOfModelsAfterRemove);
+    }
 }

--- a/tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
+++ b/tests/Integration/Domain/Repository/Identity/AdministratorTokenRepositoryTest.php
@@ -258,4 +258,23 @@ class AdministratorTokenRepositoryTest extends TestCase
 
         static::assertSame($model, $this->subject->find($model->getId()));
     }
+
+    /**
+     * @test
+     */
+    public function removeRemovesModel()
+    {
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/DetachedAdministratorTokens.csv');
+        $this->applyDatabaseChanges();
+
+        /** @var AdministratorToken[] $allModels */
+        $allModels = $this->subject->findAll();
+        $numberOfModelsBeforeRemove = count($allModels);
+        $firstModel = $allModels[0];
+
+        $this->subject->remove($firstModel);
+
+        $numberOfModelsAfterRemove = count($this->subject->findAll());
+        static::assertSame(1, $numberOfModelsBeforeRemove - $numberOfModelsAfterRemove);
+    }
 }

--- a/tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
+++ b/tests/Integration/Domain/Repository/Messaging/SubscriberListRepositoryTest.php
@@ -290,4 +290,23 @@ class SubscriberListRepositoryTest extends TestCase
         $numberOfRemovedSubscriptions = $initialNumberOfSubscriptions - $newNumberOfSubscriptions;
         static::assertSame($numberOfAssociatedSubscriptions, $numberOfRemovedSubscriptions);
     }
+
+    /**
+     * @test
+     */
+    public function removeRemovesModel()
+    {
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/SubscriberList.csv');
+        $this->applyDatabaseChanges();
+
+        /** @var SubscriberList[] $allModels */
+        $allModels = $this->subject->findAll();
+        $numberOfModelsBeforeRemove = count($allModels);
+        $firstModel = $allModels[0];
+
+        $this->subject->remove($firstModel);
+
+        $numberOfModelsAfterRemove = count($this->subject->findAll());
+        static::assertSame(1, $numberOfModelsBeforeRemove - $numberOfModelsAfterRemove);
+    }
 }

--- a/tests/Integration/Domain/Repository/Subscription/SubscriberRepositoryTest.php
+++ b/tests/Integration/Domain/Repository/Subscription/SubscriberRepositoryTest.php
@@ -295,4 +295,23 @@ class SubscriberRepositoryTest extends TestCase
         $numberOfRemovedSubscriptions = $initialNumberOfSubscriptions - $newNumberOfSubscriptions;
         static::assertSame($numberOfAssociatedSubscriptions, $numberOfRemovedSubscriptions);
     }
+
+    /**
+     * @test
+     */
+    public function removeRemovesModel()
+    {
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
+        $this->applyDatabaseChanges();
+
+        /** @var Subscriber[] $allModels */
+        $allModels = $this->subject->findAll();
+        $numberOfModelsBeforeRemove = count($allModels);
+        $firstModel = $allModels[0];
+
+        $this->subject->remove($firstModel);
+
+        $numberOfModelsAfterRemove = count($this->subject->findAll());
+        static::assertSame(1, $numberOfModelsBeforeRemove - $numberOfModelsAfterRemove);
+    }
 }

--- a/tests/Integration/Domain/Repository/Subscription/SubscriptionRepositoryTest.php
+++ b/tests/Integration/Domain/Repository/Subscription/SubscriptionRepositoryTest.php
@@ -184,7 +184,6 @@ class SubscriptionRepositoryTest extends TestCase
     {
         $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
         $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
-        $this->touchDatabaseTable(static::TABLE_NAME);
         $this->applyDatabaseChanges();
 
         /** @var Subscriber $subscriber */
@@ -205,7 +204,6 @@ class SubscriptionRepositoryTest extends TestCase
     {
         $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/../Fixtures/Subscriber.csv');
         $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
-        $this->touchDatabaseTable(static::TABLE_NAME);
         $this->applyDatabaseChanges();
 
         /** @var SubscriberList $subscriberList */
@@ -217,5 +215,24 @@ class SubscriptionRepositoryTest extends TestCase
         foreach ($result as $subscription) {
             static::assertSame($subscriberList, $subscription->getSubscriberList());
         }
+    }
+
+    /**
+     * @test
+     */
+    public function removeRemovesModel()
+    {
+        $this->getDataSet()->addTable(static::TABLE_NAME, __DIR__ . '/../Fixtures/Subscription.csv');
+        $this->applyDatabaseChanges();
+
+        /** @var Subscription[] $allModels */
+        $allModels = $this->subject->findAll();
+        $numberOfModelsBeforeRemove = count($allModels);
+        $firstModel = $allModels[0];
+
+        $this->subject->remove($firstModel);
+
+        $numberOfModelsAfterRemove = count($this->subject->findAll());
+        static::assertSame(1, $numberOfModelsBeforeRemove - $numberOfModelsAfterRemove);
     }
 }


### PR DESCRIPTION
This allows the removal of entities from controllers without
needing a refererence to the entity manager.

Also remove two redundant touchDatabaseTable calls from the integration
tests.