### PR TITLE
[CLEANUP] Move the PHPUnit configuration file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,7 +79,7 @@ code coverage of the fixed bugs and the new features.
 To run the existing unit tests, run this command:
 
 ```bash
-vendor/bin/phpunit -c Configuration/PHPUnit/phpunit.xml tests/Unit/
+vendor/bin/phpunit tests/Unit/
 ```
 
 ### Running the integration tests
@@ -102,7 +102,7 @@ and access credentials in `Configuration/parameters.yml`.
 After that has been done, you can run the integration tests:
 
 ```bash
-vendor/bin/phpunit -c Configuration/PHPUnit/phpunit.xml tests/Integration/
+vendor/bin/phpunit tests/Integration/
 ```
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,17 +64,17 @@ script:
 - >
   echo;
   echo "Running the unit tests";
-  vendor/bin/phpunit -c Configuration/PHPUnit/phpunit.xml tests/Unit/;
+  vendor/bin/phpunit tests/Unit/;
 
 - >
   echo;
   echo "Running the integration tests";
-  vendor/bin/phpunit -c Configuration/PHPUnit/phpunit.xml tests/Integration/;
+  vendor/bin/phpunit tests/Integration/;
 
 - >
   echo;
   echo "Running the system tests";
-  vendor/bin/phpunit -c Configuration/PHPUnit/phpunit.xml tests/System/;
+  vendor/bin/phpunit tests/System/;
 
 - >
   echo;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Bidirectional m:n association Subscribers/SubscriberLists (#254)
 
 ### Changed
+- Move the PHPUnit configuration file (#283)
 - Rename the Composer package to "phplist/core" (#275)
 - Remove the obsolete core classes (#267)
 - Adopt more of the default Symfony project structure (#265, #268, #269, #270)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.2/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="../../vendor/autoload.php"
+         bootstrap="vendor/autoload.php"
 >
     <php>
         <ini name="error_reporting" value="-1"/>


### PR DESCRIPTION
This brings the project more in line with the default Symfony
project structure.