### PR TITLE
Remove not existing Squiz.PHP.ForbiddenFunctions

### DIFF
--- a/config/PhpCodeSniffer/ruleset.xml
+++ b/config/PhpCodeSniffer/ruleset.xml
@@ -91,7 +91,6 @@
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
     <rule ref="Squiz.PHP.DiscouragedFunctions"/>
     <rule ref="Squiz.PHP.Eval"/>
-    <rule ref="Squiz.PHP.ForbiddenFunctions"/>
     <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.Heredoc"/>
     <rule ref="Squiz.PHP.InnerFunctions"/>


### PR DESCRIPTION
Fixes the following error message on current master:

```
$ echo; echo "Running PHP_CodeSniffer"; vendor/bin/phpcs --standard=config/PhpCodeSniffer/ bin/ src/ tests/ public/;
Running PHP_CodeSniffer
ERROR: Referenced sniff "Squiz.PHP.ForbiddenFunctions" does not exist
Run "phpcs --help" for usage information
The command "echo; echo "Running PHP_CodeSniffer"; vendor/bin/phpcs --standard=config/PhpCodeSniffer/ bin/ src/ tests/ public/;
" exited with 3.
``` 

There is still another error on master which I will fix in another PR.

Compare also the error output of https://travis-ci.org/phpList/core/jobs/395079478 with https://travis-ci.org/phpList/core/jobs/395081943