### PR TITLE
Hardcode doctrine/instantiator 1.0.5 as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "nette/caching": "^2.5.0 || ^3.0.0",
         "nikic/php-parser": "^3.1.0",
         "phpmd/phpmd": "^2.6.0",
-        "composer/composer": "^1.6.0"
+        "composer/composer": "^1.6.0",
+        "doctrine/instantiator": "^1.0.5"
     },
     "suggest": {
         "phplist/web-frontend": "4.0.x-dev",


### PR DESCRIPTION
There is a known bug in Composer (https://github.com/composer/composer/issues/7388) which makes ``--prefer-lowest` pull in a version incompatible with PHP 7.0.

Until this issue is resolved, let's hardcode 1.0.5 as dependency.

See also https://travis-ci.org/phpList/core/jobs/395091949 which is working vs. https://travis-ci.org/phpList/core/jobs/395081946 which is not.