### PR TITLE
Mark subscribers association as extra lazy.

### DIFF
--- a/src/Domain/Model/Messaging/SubscriberList.php
+++ b/src/Domain/Model/Messaging/SubscriberList.php
@@ -112,7 +112,8 @@ class SubscriberList implements DomainModel, Identity, CreationDate, Modificatio
      * @var Collection
      * @Mapping\ManyToMany(
      *     targetEntity="PhpList\Core\Domain\Model\Subscription\Subscriber",
-     *     inversedBy="subscribedLists"
+     *     inversedBy="subscribedLists",
+     *     fetch="EXTRA_LAZY"
      * )
      * @Mapping\JoinTable(name="phplist_listuser",
      *     joinColumns={@Mapping\JoinColumn(name="listid")},


### PR DESCRIPTION
### Summary
Useful for: https://github.com/phpList/rest-api/pull/116
The "count" function on the collection can be called without triggering a full load of the collection in the memory. More info: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/tutorials/extra-lazy-associations.html




Signed-off-by: Xheni Myrtaj <myrtajxheni@gmail.com>


