### PR TITLE
[BUGFIX] Fix SubscriberList to Subscriber relationship definition by …

### DIFF
--- a/src/Domain/Model/Subscription/Subscriber.php
+++ b/src/Domain/Model/Subscription/Subscriber.php
@@ -118,7 +118,7 @@ class Subscriber implements DomainModel, Identity, CreationDate, ModificationDat
 
     /**
      * @var Collection
-     * @Mapping\ManyToMany(targetEntity="PhpList\Core\Domain\Model\Messaging\SubscriberList", inversedBy="subscribers")
+     * @Mapping\ManyToMany(targetEntity="PhpList\Core\Domain\Model\Messaging\SubscriberList", mappedBy="subscribers")
      * @Mapping\JoinTable(name="phplist_listuser",
      *     joinColumns={@Mapping\JoinColumn(name="userid")},
      *     inverseJoinColumns={@Mapping\JoinColumn(name="listid")}


### PR DESCRIPTION
…adding changing invertedBy to mappedBy in Subscriber

### Summary

[Doctrine bidirectional many to many relationship](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/association-mapping.html#many-to-many-bidirectional) requires an `invertedBy` mapping and a `mappedBy` one.

Fixes validation error as per issue #311 