### PR TITLE
[BUGFIX] Remove the roave/security-advisories dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,6 @@
     "require": {
         "php": "~7.0.0 || ~7.1.0 || ~7.2.0",
 
-        "roave/security-advisories": "dev-master",
-
         "doctrine/orm": "^2.5.0",
         "doctrine/common": "^2.6.0",
         "doctrine/doctrine-bundle": "^1.8.0",


### PR DESCRIPTION
1. This dependency should only be a dev dependency, not a production
   dependency, so that is kicks in when we update packages.
2. This package is intended to be used only for projects and distributions,
   not for libraries (like this package).
