### PR TITLE
Add a dryRun option to subscriber csv import

### DIFF
--- a/src/Domain/Subscription/Model/Dto/SubscriberImportOptions.php
+++ b/src/Domain/Subscription/Model/Dto/SubscriberImportOptions.php
@@ -12,6 +12,7 @@ class SubscriberImportOptions
     public function __construct(
         public readonly bool $updateExisting = false,
         public readonly array $listIds = [],
+        public readonly bool $dryRun = false,
     ) {
     }
 }

--- a/src/Domain/Subscription/Service/Manager/SubscriberAttributeManager.php
+++ b/src/Domain/Subscription/Service/Manager/SubscriberAttributeManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpList\Core\Domain\Subscription\Service\Manager;
 
+use Doctrine\ORM\EntityManagerInterface;
 use PhpList\Core\Domain\Subscription\Exception\SubscriberAttributeCreationException;
 use PhpList\Core\Domain\Subscription\Model\Subscriber;
 use PhpList\Core\Domain\Subscription\Model\SubscriberAttributeDefinition;
@@ -13,10 +14,14 @@ use PhpList\Core\Domain\Subscription\Repository\SubscriberAttributeValueReposito
 class SubscriberAttributeManager
 {
     private SubscriberAttributeValueRepository $attributeRepository;
+    private EntityManagerInterface $entityManager;
 
-    public function __construct(SubscriberAttributeValueRepository $attributeRepository)
-    {
+    public function __construct(
+        SubscriberAttributeValueRepository $attributeRepository,
+        EntityManagerInterface $entityManager,
+    ) {
         $this->attributeRepository = $attributeRepository;
+        $this->entityManager = $entityManager;
     }
 
     public function createOrUpdate(
@@ -37,7 +42,7 @@ class SubscriberAttributeManager
         }
 
         $subscriberAttribute->setValue($value);
-        $this->attributeRepository->save($subscriberAttribute);
+        $this->entityManager->persist($subscriberAttribute);
 
         return $subscriberAttribute;
     }

--- a/src/Domain/Subscription/Service/Manager/SubscriberManager.php
+++ b/src/Domain/Subscription/Service/Manager/SubscriberManager.php
@@ -120,7 +120,7 @@ class SubscriberManager
         $subscriber->setDisabled($subscriberDto->disabled);
         $subscriber->setExtraData($subscriberDto->extraData);
 
-        $this->subscriberRepository->save($subscriber);
+        $this->entityManager->persist($subscriber);
 
         return $subscriber;
     }

--- a/tests/Unit/Domain/Subscription/Service/SubscriberAttributeManagerTest.php
+++ b/tests/Unit/Domain/Subscription/Service/SubscriberAttributeManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpList\Core\Tests\Unit\Domain\Subscription\Service;
 
+use Doctrine\ORM\EntityManagerInterface;
 use PhpList\Core\Domain\Subscription\Exception\SubscriberAttributeCreationException;
 use PhpList\Core\Domain\Subscription\Model\Subscriber;
 use PhpList\Core\Domain\Subscription\Model\SubscriberAttributeDefinition;
@@ -20,19 +21,20 @@ class SubscriberAttributeManagerTest extends TestCase
         $definition = new SubscriberAttributeDefinition();
 
         $subscriberAttrRepo = $this->createMock(SubscriberAttributeValueRepository::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
 
         $subscriberAttrRepo->expects(self::once())
             ->method('findOneBySubscriberAndAttribute')
             ->with($subscriber, $definition)
             ->willReturn(null);
 
-        $subscriberAttrRepo->expects(self::once())
-            ->method('save')
+        $entityManager->expects(self::once())
+            ->method('persist')
             ->with(self::callback(function (SubscriberAttributeValue $attr) {
                 return $attr->getValue() === 'US';
             }));
 
-        $manager = new SubscriberAttributeManager($subscriberAttrRepo);
+        $manager = new SubscriberAttributeManager($subscriberAttrRepo, $entityManager);
         $attribute = $manager->createOrUpdate($subscriber, $definition, 'US');
 
         self::assertInstanceOf(SubscriberAttributeValue::class, $attribute);
@@ -47,16 +49,18 @@ class SubscriberAttributeManagerTest extends TestCase
         $existing->setValue('Old');
 
         $subscriberAttrRepo = $this->createMock(SubscriberAttributeValueRepository::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
         $subscriberAttrRepo->expects(self::once())
             ->method('findOneBySubscriberAndAttribute')
             ->with($subscriber, $definition)
             ->willReturn($existing);
 
-        $subscriberAttrRepo->expects(self::once())
-            ->method('save')
+        $entityManager->expects(self::once())
+            ->method('persist')
             ->with($existing);
 
-        $manager = new SubscriberAttributeManager($subscriberAttrRepo);
+        $manager = new SubscriberAttributeManager($subscriberAttrRepo, $entityManager);
         $result = $manager->createOrUpdate($subscriber, $definition, 'Updated');
 
         self::assertSame('Updated', $result->getValue());
@@ -68,9 +72,11 @@ class SubscriberAttributeManagerTest extends TestCase
         $definition = new SubscriberAttributeDefinition();
 
         $subscriberAttrRepo = $this->createMock(SubscriberAttributeValueRepository::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
         $subscriberAttrRepo->method('findOneBySubscriberAndAttribute')->willReturn(null);
 
-        $manager = new SubscriberAttributeManager($subscriberAttrRepo);
+        $manager = new SubscriberAttributeManager($subscriberAttrRepo, $entityManager);
 
         $this->expectException(SubscriberAttributeCreationException::class);
         $this->expectExceptionMessage('Value is required');
@@ -81,14 +87,15 @@ class SubscriberAttributeManagerTest extends TestCase
     public function testGetSubscriberAttribute(): void
     {
         $subscriberAttrRepo = $this->createMock(SubscriberAttributeValueRepository::class);
-        $expected = new SubscriberAttributeValue(new SubscriberAttributeDefinition(), new Subscriber());
+        $entityManager = $this->createMock(EntityManagerInterface::class);
 
+        $expected = new SubscriberAttributeValue(new SubscriberAttributeDefinition(), new Subscriber());
         $subscriberAttrRepo->expects(self::once())
             ->method('findOneBySubscriberIdAndAttributeId')
             ->with(5, 10)
             ->willReturn($expected);
 
-        $manager = new SubscriberAttributeManager($subscriberAttrRepo);
+        $manager = new SubscriberAttributeManager($subscriberAttrRepo, $entityManager);
         $result = $manager->getSubscriberAttribute(5, 10);
 
         self::assertSame($expected, $result);
@@ -98,12 +105,13 @@ class SubscriberAttributeManagerTest extends TestCase
     {
         $subscriberAttrRepo = $this->createMock(SubscriberAttributeValueRepository::class);
         $attribute = $this->createMock(SubscriberAttributeValue::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
 
         $subscriberAttrRepo->expects(self::once())
             ->method('remove')
             ->with($attribute);
 
-        $manager = new SubscriberAttributeManager($subscriberAttrRepo);
+        $manager = new SubscriberAttributeManager($subscriberAttrRepo, $entityManager);
         $manager->delete($attribute);
 
         self::assertTrue(true);

--- a/tests/Unit/Domain/Subscription/Service/SubscriberCsvImportManagerTest.php
+++ b/tests/Unit/Domain/Subscription/Service/SubscriberCsvImportManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpList\Core\Tests\Unit\Domain\Subscription\Service;
 
+use Doctrine\ORM\EntityManagerInterface;
 use PhpList\Core\Domain\Subscription\Model\Dto\ImportSubscriberDto;
 use PhpList\Core\Domain\Subscription\Model\Dto\SubscriberImportOptions;
 use PhpList\Core\Domain\Subscription\Model\Subscriber;
@@ -27,6 +28,7 @@ class SubscriberCsvImportManagerTest extends TestCase
     private SubscriberRepository&MockObject $subscriberRepositoryMock;
     private CsvImporter&MockObject $csvImporterMock;
     private SubscriberAttributeDefinitionRepository&MockObject $attributeDefinitionRepositoryMock;
+    private EntityManagerInterface $entityManager;
     private SubscriberCsvImporter $subject;
 
     protected function setUp(): void
@@ -37,14 +39,16 @@ class SubscriberCsvImportManagerTest extends TestCase
         $this->subscriberRepositoryMock = $this->createMock(SubscriberRepository::class);
         $this->csvImporterMock = $this->createMock(CsvImporter::class);
         $this->attributeDefinitionRepositoryMock = $this->createMock(SubscriberAttributeDefinitionRepository::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
 
         $this->subject = new SubscriberCsvImporter(
-            $this->subscriberManagerMock,
-            $this->attributeManagerMock,
-            $this->subscriptionManagerMock,
-            $this->subscriberRepositoryMock,
-            $this->csvImporterMock,
-            $this->attributeDefinitionRepositoryMock
+            subscriberManager: $this->subscriberManagerMock,
+            attributeManager: $this->attributeManagerMock,
+            subscriptionManager: $this->subscriptionManagerMock,
+            subscriberRepository: $this->subscriberRepositoryMock,
+            csvImporter: $this->csvImporterMock,
+            attrDefinitionRepository: $this->attributeDefinitionRepositoryMock,
+            entityManager: $this->entityManager,
         );
     }
 


### PR DESCRIPTION
### Summary

- Add a dryRun option to subscriber csv import that will not persist data in DB

### Unit test

Are your changes covered with unit tests, and do they not break anything?

You can run the existing unit tests using this command:

    vendor/bin/phpunit tests/


### Code style

Have you checked that you code is well-documented and follows the PSR-2 coding
style?

You can check for this using this command:

    vendor/bin/phpcs --standard=PSR2 src/ tests/


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include benchmarks,
or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing to phpList!
