### PR TITLE
Remove to from MessagePrecacheDto

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,9 @@ reviews:
   suggested_labels: false
   high_level_summary_in_walkthrough: false
   poem: false
+  finishing_touches:
+    docstrings:
+      enabled: false
   path_instructions:
     - path: "src/Domain/**"
       instructions: |

--- a/src/Domain/Identity/Service/AdminCopyEmailSender.php
+++ b/src/Domain/Identity/Service/AdminCopyEmailSender.php
@@ -39,11 +39,10 @@ class AdminCopyEmailSender
 
         foreach ($mails as $adminMail) {
             $data = new MessagePrecacheDto();
-            $data->to = $adminMail;
             $data->subject = $this->installationName . ' ' . $subject;
             $data->content = $message;
 
-            $email = $this->systemEmailBuilder->buildSystemEmail(data: $data);
+            $email = $this->systemEmailBuilder->buildSystemEmail(data: $data, toEmail: $adminMail);
             if ($email === null) {
                 $this->logger->warning('Failed to build admin copy email for recipient ' . $adminMail);
                 continue;

--- a/src/Domain/Messaging/MessageHandler/CampaignProcessorMessageHandler.php
+++ b/src/Domain/Messaging/MessageHandler/CampaignProcessorMessageHandler.php
@@ -243,7 +243,7 @@ class CampaignProcessorMessageHandler
             $email = $this->systemEmailBuilder->buildCampaignEmail(
                 messageId: $campaign->getId(),
                 data: $data,
-                toEmail: $this->configProvider->getValue(ConfigOption::ReportAddress),
+                toEmail: $this->configProvider->getValue(ConfigOption::ReportAddress) ?? '',
             );
 
             $envelope = new Envelope(

--- a/src/Domain/Messaging/MessageHandler/CampaignProcessorMessageHandler.php
+++ b/src/Domain/Messaging/MessageHandler/CampaignProcessorMessageHandler.php
@@ -210,6 +210,7 @@ class CampaignProcessorMessageHandler
             $result = $this->campaignEmailBuilder->buildCampaignEmail(
                 messageId: $campaign->getId(),
                 data: $processed,
+                toEmail: $subscriber->getEmail(),
                 skipBlacklistCheck: false,
                 inBlast: true,
                 htmlPref: $subscriber->hasHtmlEmail(),
@@ -236,13 +237,13 @@ class CampaignProcessorMessageHandler
             $this->updateUserMessageStatus($userMessage, UserMessageStatus::NotSent);
 
             $data = new MessagePrecacheDto();
-            $data->to = $this->configProvider->getValue(ConfigOption::ReportAddress);
             $data->subject = $this->translator->trans('phpList system error');
             $data->content = $this->translator->trans($e->getMessage());
 
             $email = $this->systemEmailBuilder->buildCampaignEmail(
                 messageId: $campaign->getId(),
                 data: $data,
+                toEmail: $this->configProvider->getValue(ConfigOption::ReportAddress),
             );
 
             $envelope = new Envelope(
@@ -270,7 +271,6 @@ class CampaignProcessorMessageHandler
             $notifications = explode(',', $loadedMessageData['notify_start']);
             foreach ($notifications as $notification) {
                 $data = new MessagePrecacheDto();
-                $data->to = $notification;
                 $data->subject = $this->translator->trans('Campaign started');
                 $data->content = $this->translator->trans(
                     'phplist has started sending the campaign with subject %subject%',
@@ -280,6 +280,7 @@ class CampaignProcessorMessageHandler
                 $email = $this->systemEmailBuilder->buildCampaignEmail(
                     messageId: $campaign->getId(),
                     data: $data,
+                    toEmail: $notification
                 );
 
                 if (!$email) {

--- a/src/Domain/Messaging/Model/Dto/MessagePrecacheDto.php
+++ b/src/Domain/Messaging/Model/Dto/MessagePrecacheDto.php
@@ -11,7 +11,6 @@ class MessagePrecacheDto
     public ?string $replyToName = null;
     public ?string $fromName = null;
     public ?string $fromEmail = null;
-    public ?string $to = null;
     public string $subject = '';
     public string $content = '';
     public string $textContent = '';
@@ -23,8 +22,6 @@ class MessagePrecacheDto
     public ?string $template = null;
     public ?string $templateText = null;
     public ?int $templateId = null;
-//    public string $htmlCharset= 'UTF-8';
-//    public string $textCharset= 'UTF-8';
     public bool $userSpecificUrl = false;
     public bool $googleTrack = false;
     public array $adminAttributes = [];

--- a/src/Domain/Messaging/Service/Builder/BaseEmailBuilder.php
+++ b/src/Domain/Messaging/Service/Builder/BaseEmailBuilder.php
@@ -61,7 +61,6 @@ abstract class BaseEmailBuilder
 
     protected function passesBlacklistCheck(string $to, ?bool $skipBlacklistCheck): bool
     {
-
         if (!$skipBlacklistCheck && $this->blacklistRepository->isEmailBlacklisted($to)) {
             $this->eventLogManager->log('', sprintf('Error, %s is blacklisted, not sending', $to));
             $subscriber = $this->subscriberRepository->findOneByEmail($to);
@@ -103,7 +102,7 @@ abstract class BaseEmailBuilder
         ?string $fromEmail,
         ?string $fromName,
         ?string $subject,
-    ) : Email {
+    ): Email {
         $email = (new Email());
         $destinationEmail = $this->resolveDestinationEmail($to);
 

--- a/src/Domain/Messaging/Service/Builder/EmailBuilder.php
+++ b/src/Domain/Messaging/Service/Builder/EmailBuilder.php
@@ -69,16 +69,17 @@ class EmailBuilder extends BaseEmailBuilder
     public function buildCampaignEmail(
         int $messageId,
         MessagePrecacheDto $data,
+        string $toEmail,
         ?bool $skipBlacklistCheck = false,
         ?bool $inBlast = true,
         ?bool $htmlPref = false,
         ?bool $isTestMail = false,
     ): ?array {
-        if (!$this->validateRecipientAndSubject(to: $data->to, subject: $data->subject)) {
+        if (!$this->validateRecipientAndSubject(to: $toEmail, subject: $data->subject)) {
             return null;
         }
 
-        if (!$this->passesBlacklistCheck(to: $data->to, skipBlacklistCheck: $skipBlacklistCheck)) {
+        if (!$this->passesBlacklistCheck(to: $toEmail, skipBlacklistCheck: $skipBlacklistCheck)) {
             return null;
         }
 
@@ -87,7 +88,7 @@ class EmailBuilder extends BaseEmailBuilder
         $subject = (!$isTestMail ? '' : $this->translator->trans('(test)') .  ' ') . $data->subject;
 
         $email = $this->createBaseEmail(
-            to: $data->to,
+            to: $toEmail,
             fromEmail: $fromEmail,
             fromName: $fromName,
             subject: $subject,
@@ -95,7 +96,7 @@ class EmailBuilder extends BaseEmailBuilder
         $this->addBaseCampaignHeaders(
             email: $email,
             messageId: $messageId,
-            originalTo: $data->to,
+            originalTo: $toEmail,
             destinationEmail: $email->getTo()[0]->getAddress(),
             inBlast: $inBlast,
         );
@@ -109,7 +110,11 @@ class EmailBuilder extends BaseEmailBuilder
             }
         }
 
-        [$htmlMessage, $textMessage] = ($this->mailContentBuilder)(messagePrecacheDto: $data, campaignId: $messageId);
+        [$htmlMessage, $textMessage] = ($this->mailContentBuilder)(
+            messagePrecacheDto: $data,
+            toEmail: $toEmail,
+            campaignId: $messageId,
+        );
         $sentAs = $this->applyContentAndFormatting(
             email: $email,
             htmlMessage: $htmlMessage,

--- a/src/Domain/Messaging/Service/Builder/EmailBuilder.php
+++ b/src/Domain/Messaging/Service/Builder/EmailBuilder.php
@@ -11,6 +11,7 @@ use PhpList\Core\Domain\Configuration\Service\LegacyUrlBuilder;
 use PhpList\Core\Domain\Configuration\Service\Manager\EventLogManager;
 use PhpList\Core\Domain\Configuration\Service\Provider\ConfigProvider;
 use PhpList\Core\Domain\Messaging\Exception\AttachmentException;
+use PhpList\Core\Domain\Messaging\Exception\SubscriberNotFoundException;
 use PhpList\Core\Domain\Messaging\Model\Dto\MessagePrecacheDto;
 use PhpList\Core\Domain\Messaging\Service\AttachmentAdder;
 use PhpList\Core\Domain\Messaging\Service\Constructor\CampaignMailContentBuilder;
@@ -65,7 +66,10 @@ class EmailBuilder extends BaseEmailBuilder
         );
     }
 
-    /** @return array{Email, OutputFormat}|null */
+    /**
+     * @return array{Email, OutputFormat}|null
+     * @throws SubscriberNotFoundException
+     */
     public function buildCampaignEmail(
         int $messageId,
         MessagePrecacheDto $data,
@@ -110,9 +114,16 @@ class EmailBuilder extends BaseEmailBuilder
             }
         }
 
+        $receiver = $this->subscriberRepository->findOneByEmail($toEmail);
+        if (!$receiver) {
+            throw new SubscriberNotFoundException(
+                sprintf('Subscriber with email %s not found', $toEmail)
+            );
+        }
+
         [$htmlMessage, $textMessage] = ($this->mailContentBuilder)(
             messagePrecacheDto: $data,
-            toEmail: $toEmail,
+            receiver: $receiver,
             campaignId: $messageId,
         );
         $sentAs = $this->applyContentAndFormatting(

--- a/src/Domain/Messaging/Service/Builder/ForwardEmailBuilder.php
+++ b/src/Domain/Messaging/Service/Builder/ForwardEmailBuilder.php
@@ -96,9 +96,11 @@ class ForwardEmailBuilder extends EmailBuilder
 
         $subject = $this->translator->trans('Fwd') . ': ' . stripslashes($data->subject);
 
+        $receiver = $this->subscriberRepository->findOneByEmail($friendEmail) ?? (new Subscriber($friendEmail));
+
         [$htmlMessage, $textMessage] = ($this->mailContentBuilder)(
             messagePrecacheDto: $data,
-            toEmail: $friendEmail,
+            receiver: $receiver,
             campaignId: $messageId,
             forwardedBy: $forwardedBy,
             forwardedPersonalNote: $forwardedPersonalNote,

--- a/src/Domain/Messaging/Service/Builder/ForwardEmailBuilder.php
+++ b/src/Domain/Messaging/Service/Builder/ForwardEmailBuilder.php
@@ -98,6 +98,7 @@ class ForwardEmailBuilder extends EmailBuilder
 
         [$htmlMessage, $textMessage] = ($this->mailContentBuilder)(
             messagePrecacheDto: $data,
+            toEmail: $friendEmail,
             campaignId: $messageId,
             forwardedBy: $forwardedBy,
             forwardedPersonalNote: $forwardedPersonalNote,

--- a/src/Domain/Messaging/Service/Builder/SystemEmailBuilder.php
+++ b/src/Domain/Messaging/Service/Builder/SystemEmailBuilder.php
@@ -53,13 +53,14 @@ class SystemEmailBuilder extends BaseEmailBuilder
     public function buildCampaignEmail(
         int $messageId,
         MessagePrecacheDto $data,
+        string $toEmail,
         ?bool $skipBlacklistCheck = false,
     ): ?Email {
-        if (!$this->validateRecipientAndSubject(to: $data->to, subject: $data->subject)) {
+        if (!$this->validateRecipientAndSubject(to: $toEmail, subject: $data->subject)) {
             return null;
         }
 
-        if (!$this->passesBlacklistCheck(to: $data->to, skipBlacklistCheck: $skipBlacklistCheck)) {
+        if (!$this->passesBlacklistCheck(to: $toEmail, skipBlacklistCheck: $skipBlacklistCheck)) {
             return null;
         }
 
@@ -69,7 +70,7 @@ class SystemEmailBuilder extends BaseEmailBuilder
         $replyTo = $messageReplyToAddress ?: $fromEmail;
 
         $email = $this->createBaseEmail(
-            to: $data->to,
+            to: $toEmail,
             fromEmail: $fromEmail,
             fromName: $fromName,
             subject: $data->subject,
@@ -79,7 +80,7 @@ class SystemEmailBuilder extends BaseEmailBuilder
         $this->addBaseCampaignHeaders(
             email: $email,
             messageId: $messageId,
-            originalTo: $data->to,
+            originalTo: $toEmail,
             destinationEmail: $email->getTo()[0]->getAddress(),
             inBlast: false,
         );
@@ -97,13 +98,14 @@ class SystemEmailBuilder extends BaseEmailBuilder
 
     public function buildSystemEmail(
         MessagePrecacheDto $data,
+        string $toEmail,
         ?bool $skipBlacklistCheck = false,
     ): ?Email {
-        if (!$this->validateRecipientAndSubject(to: $data->to, subject: $data->subject)) {
+        if (!$this->validateRecipientAndSubject(to: $toEmail, subject: $data->subject)) {
             return null;
         }
 
-        if (!$this->passesBlacklistCheck(to: $data->to, skipBlacklistCheck: $skipBlacklistCheck)) {
+        if (!$this->passesBlacklistCheck(to: $toEmail, skipBlacklistCheck: $skipBlacklistCheck)) {
             return null;
         }
 
@@ -113,14 +115,14 @@ class SystemEmailBuilder extends BaseEmailBuilder
         $replyTo = $messageReplyToAddress ?: $fromEmail;
 
         $email = $this->createBaseEmail(
-            to: $data->to,
+            to: $toEmail,
             fromEmail: $fromEmail,
             fromName: $fromName,
             subject: $data->subject,
         );
         $email->replyTo($replyTo);
 
-        $this->addSystemHeaders(email: $email, originalTo: $data->to,);
+        $this->addSystemHeaders(email: $email, originalTo: $toEmail);
 
         [$htmlMessage, $textMessage] = ($this->mailConstructor)(messagePrecacheDto: $data);
         $email->text($textMessage);

--- a/src/Domain/Messaging/Service/Constructor/CampaignMailContentBuilder.php
+++ b/src/Domain/Messaging/Service/Constructor/CampaignMailContentBuilder.php
@@ -16,7 +16,6 @@ use PhpList\Core\Domain\Messaging\Exception\RemotePageFetchException;
 use PhpList\Core\Domain\Messaging\Model\Dto\MessagePrecacheDto;
 use PhpList\Core\Domain\Subscription\Model\Subscriber;
 use PhpList\Core\Domain\Subscription\Repository\SubscriberRepository;
-use PhpList\Core\Domain\Messaging\Exception\SubscriberNotFoundException;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 class CampaignMailContentBuilder
@@ -35,22 +34,16 @@ class CampaignMailContentBuilder
 
     public function __invoke(
         MessagePrecacheDto $messagePrecacheDto,
-        string $toEmail,
+        Subscriber $receiver,
         ?int $campaignId = null,
         ?Subscriber $forwardedBy = null,
         ?string $forwardedPersonalNote = null,
     ): array {
-        $subscriber = $this->subscriberRepository->findOneByEmail($toEmail);
-        if (!$subscriber) {
-            throw new SubscriberNotFoundException(
-                sprintf('Subscriber with email %s not found', $toEmail)
-            );
-        }
         $addDefaultStyle = false;
 
-        if ($messagePrecacheDto->userSpecificUrl) {
-            $userData = $this->subscriberRepository->getDataById($subscriber->getId());
-            $this->replaceUserSpecificRemoteContent($messagePrecacheDto, $subscriber, $userData);
+        if ($messagePrecacheDto->userSpecificUrl && $receiver->getId()) {
+            $userData = $this->subscriberRepository->getDataById($receiver->getId());
+            $this->replaceUserSpecificRemoteContent($messagePrecacheDto, $receiver, $userData);
         }
 
         $content = $messagePrecacheDto->content;
@@ -81,7 +74,7 @@ class CampaignMailContentBuilder
 
         $textMessage = $this->placeholderProcessor->process(
             value: $textMessage,
-            receiver: $subscriber,
+            receiver: $receiver,
             format: OutputFormat::Text,
             messagePrecacheDto: $messagePrecacheDto,
             campaignId: $campaignId,
@@ -90,7 +83,7 @@ class CampaignMailContentBuilder
 
         $htmlMessage = $this->placeholderProcessor->process(
             value: $htmlMessage,
-            receiver: $subscriber,
+            receiver: $receiver,
             format: OutputFormat::Html,
             messagePrecacheDto: $messagePrecacheDto,
             campaignId: $campaignId,

--- a/src/Domain/Messaging/Service/Constructor/CampaignMailContentBuilder.php
+++ b/src/Domain/Messaging/Service/Constructor/CampaignMailContentBuilder.php
@@ -35,14 +35,15 @@ class CampaignMailContentBuilder
 
     public function __invoke(
         MessagePrecacheDto $messagePrecacheDto,
+        string $toEmail,
         ?int $campaignId = null,
         ?Subscriber $forwardedBy = null,
         ?string $forwardedPersonalNote = null,
     ): array {
-        $subscriber = $this->subscriberRepository->findOneByEmail($messagePrecacheDto->to);
+        $subscriber = $this->subscriberRepository->findOneByEmail($toEmail);
         if (!$subscriber) {
             throw new SubscriberNotFoundException(
-                sprintf('Subscriber with email %s not found', $messagePrecacheDto->to)
+                sprintf('Subscriber with email %s not found', $toEmail)
             );
         }
         $addDefaultStyle = false;

--- a/src/Domain/Messaging/Service/MessageDataLoader.php
+++ b/src/Domain/Messaging/Service/MessageDataLoader.php
@@ -82,7 +82,6 @@ class MessageDataLoader
             'footer' => $this->configProvider->getValue(ConfigOption::MessageFooter),
             'forwardfooter' => $this->configProvider->getValue(ConfigOption::ForwardFooter),
             'status' => '',
-            'tofield' => '',
             'replyto' => '',
             'targetlist' => [],
             'criteria_match' => '',

--- a/src/Domain/Messaging/Service/MessagePrecacheService.php
+++ b/src/Domain/Messaging/Service/MessagePrecacheService.php
@@ -135,7 +135,6 @@ class MessagePrecacheService
     ): void {
         $messagePrecacheDto->fromName = $loadedMessageData['fromname'];
         $messagePrecacheDto->fromEmail = $loadedMessageData['fromemail'];
-        $messagePrecacheDto->to = $loadedMessageData['tofield'];
 
         //0013076: different content when forwarding 'to a friend'
         $messagePrecacheDto->subject = $forwardContent

--- a/src/Domain/Subscription/Model/Subscriber.php
+++ b/src/Domain/Subscription/Model/Subscriber.php
@@ -109,8 +109,9 @@ class Subscriber implements DomainModel, Identity, CreationDate, ModificationDat
     #[ORM\Column(name: 'foreignkey', type: 'string', length: 100, nullable: true)]
     private ?string $foreignKey = null;
 
-    public function __construct()
+    public function __construct(string $email)
     {
+        $this->email = $email;
         $this->subscriptions = new ArrayCollection();
         $this->attributes = new ArrayCollection();
         $this->extraData = '';

--- a/src/Domain/Subscription/Service/Manager/SubscriberManager.php
+++ b/src/Domain/Subscription/Service/Manager/SubscriberManager.php
@@ -40,8 +40,7 @@ class SubscriberManager
 
     public function createSubscriber(CreateSubscriberDto $subscriberDto): Subscriber
     {
-        $subscriber = new Subscriber();
-        $subscriber->setEmail($subscriberDto->email);
+        $subscriber = new Subscriber($subscriberDto->email);
         $confirmed = (bool)$subscriberDto->requestConfirmation;
         $subscriber->setConfirmed(!$confirmed);
         $subscriber->setBlacklisted(false);
@@ -106,8 +105,7 @@ class SubscriberManager
 
     public function createFromImport(ImportSubscriberDto $subscriberDto): Subscriber
     {
-        $subscriber = new Subscriber();
-        $subscriber->setEmail($subscriberDto->email);
+        $subscriber = new Subscriber($subscriberDto->email);
         $subscriber->setConfirmed($subscriberDto->confirmed);
         $subscriber->setBlacklisted($subscriberDto->blacklisted);
         $subscriber->setHtmlEmail($subscriberDto->htmlEmail);

--- a/tests/Integration/Domain/Subscription/Fixtures/SubscriberFixture.php
+++ b/tests/Integration/Domain/Subscription/Fixtures/SubscriberFixture.php
@@ -37,10 +37,9 @@ class SubscriberFixture extends Fixture
             }
             $row = array_combine($headers, $data);
 
-            $subscriber = new Subscriber();
+            $subscriber = new Subscriber($row['email']);
             $this->setSubjectId($subscriber, (int)$row['id']);
 
-            $subscriber->setEmail($row['email']);
             $subscriber->setConfirmed((bool) $row['confirmed']);
             $subscriber->setBlacklisted((bool) $row['blacklisted']);
             $subscriber->setBounceCount((int) $row['bouncecount']);

--- a/tests/Integration/Domain/Subscription/Repository/SubscriberRepositoryTest.php
+++ b/tests/Integration/Domain/Subscription/Repository/SubscriberRepositoryTest.php
@@ -79,8 +79,7 @@ class SubscriberRepositoryTest extends KernelTestCase
 
     public function testCreationDateOfNewModelIsSetToNowOnPersist()
     {
-        $model = new Subscriber();
-        $model->setEmail('sam@example.com');
+        $model = new Subscriber('sam@example.com');
         $expectedCreationDate = new DateTime();
 
         $this->entityManager->persist($model);
@@ -90,8 +89,7 @@ class SubscriberRepositoryTest extends KernelTestCase
 
     public function testModificationDateOfNewModelIsSetToNowOnPersist()
     {
-        $model = new Subscriber();
-        $model->setEmail('oliver@example.com');
+        $model = new Subscriber('oliver@example.com');
         $expectedModificationDate = new DateTime();
 
         $this->entityManager->persist($model);
@@ -101,8 +99,7 @@ class SubscriberRepositoryTest extends KernelTestCase
 
     public function testSavePersistsAndFlushesModel()
     {
-        $model = new Subscriber();
-        $model->setEmail('michiel@example.com');
+        $model = new Subscriber('michiel@example.com');
         $this->subscriberRepository->save($model);
 
         self::assertSame($model, $this->subscriberRepository->find($model->getId()));
@@ -115,9 +112,8 @@ class SubscriberRepositoryTest extends KernelTestCase
         /** @var Subscriber $model */
         $model = $this->subscriberRepository->find(1);
 
-        $otherModel = new Subscriber();
+        $otherModel = new Subscriber($model->getEmail());
         $otherModel->generateUniqueId();
-        $otherModel->setEmail($model->getEmail());
 
         $this->expectException(UniqueConstraintViolationException::class);
 
@@ -126,9 +122,7 @@ class SubscriberRepositoryTest extends KernelTestCase
 
     public function testUniqueIdOfNewModelIsGeneratedOnPersist()
     {
-        $model = new Subscriber();
-        $model->setEmail('oliver@example.com');
-
+        $model = new Subscriber('oliver@example.com');
         $this->entityManager->persist($model);
 
         self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $model->getUniqueId());

--- a/tests/Integration/Domain/Subscription/Service/SubscriberCsvExportManagerTest.php
+++ b/tests/Integration/Domain/Subscription/Service/SubscriberCsvExportManagerTest.php
@@ -35,8 +35,7 @@ class SubscriberCsvExportManagerTest extends KernelTestCase
 
     public function testExportToCsvReturnsStreamedResponse(): void
     {
-        $subscriber1 = new Subscriber();
-        $subscriber1->setEmail('test1@example.com');
+        $subscriber1 = new Subscriber('test1@example.com');
         $subscriber1->setConfirmed(true);
         $subscriber1->setHtmlEmail(true);
         $subscriber1->setBlacklisted(false);
@@ -44,8 +43,7 @@ class SubscriberCsvExportManagerTest extends KernelTestCase
         $subscriber1->setExtraData('Data 1');
         $this->entityManager->persist($subscriber1);
 
-        $subscriber2 = new Subscriber();
-        $subscriber2->setEmail('test2@example.com');
+        $subscriber2 = new Subscriber('test2@example.com');
         $subscriber2->setConfirmed(false);
         $subscriber2->setHtmlEmail(false);
         $subscriber2->setBlacklisted(true);

--- a/tests/Integration/Domain/Subscription/Service/SubscriberCsvImportManagerTest.php
+++ b/tests/Integration/Domain/Subscription/Service/SubscriberCsvImportManagerTest.php
@@ -95,8 +95,7 @@ class SubscriberCsvImportManagerTest extends KernelTestCase
 
     public function testImportFromCsvUpdatesExistingSubscribers(): void
     {
-        $subscriber = new Subscriber();
-        $subscriber->setEmail('existing@example.com');
+        $subscriber = new Subscriber('existing@example.com');
         $subscriber->setConfirmed(false);
         $subscriber->setHtmlEmail(false);
         $subscriber->setBlacklisted(true);

--- a/tests/Integration/Domain/Subscription/Service/SubscriberDeletionServiceTest.php
+++ b/tests/Integration/Domain/Subscription/Service/SubscriberDeletionServiceTest.php
@@ -66,8 +66,7 @@ class SubscriberDeletionServiceTest extends KernelTestCase
         );
         $this->entityManager->persist($msg);
 
-        $subscriber = new Subscriber();
-        $subscriber->setEmail('test-delete@example.com');
+        $subscriber = new Subscriber('test-delete@example.com');
         $subscriber->setConfirmed(true);
         $subscriber->setHtmlEmail(true);
         $subscriber->setBlacklisted(false);

--- a/tests/Unit/Domain/Configuration/Service/MessagePlaceholderProcessorTest.php
+++ b/tests/Unit/Domain/Configuration/Service/MessagePlaceholderProcessorTest.php
@@ -35,8 +35,7 @@ final class MessagePlaceholderProcessorTest extends TestCase
 
     private function makeUser(string $email = 'user@example.com', string $uid = 'UID123'): Subscriber
     {
-        $user = new Subscriber();
-        $user->setEmail($email);
+        $user = new Subscriber($email);
         $user->setUniqueId($uid);
         return $user;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/BlacklistUrlValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/BlacklistUrlValueResolverTest.php
@@ -27,8 +27,7 @@ final class BlacklistUrlValueResolverTest extends TestCase
 
     private function makeUser(string $email = 'user@example.com'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail($email);
+        $u = new Subscriber($email);
         $u->setUniqueId('UID-123');
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/BlacklistValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/BlacklistValueResolverTest.php
@@ -30,8 +30,7 @@ final class BlacklistValueResolverTest extends TestCase
 
     private function makeUser(string $email = 'user@example.com'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail($email);
+        $u = new Subscriber($email);
         $u->setUniqueId('UID-1');
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/ConfirmationUrlValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/ConfirmationUrlValueResolverTest.php
@@ -24,8 +24,7 @@ final class ConfirmationUrlValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'UID-1'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/ContactUrlValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/ContactUrlValueResolverTest.php
@@ -24,8 +24,7 @@ final class ContactUrlValueResolverTest extends TestCase
 
     private function makeUser(): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId('UID-1');
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/ContactValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/ContactValueResolverTest.php
@@ -27,8 +27,7 @@ final class ContactValueResolverTest extends TestCase
 
     private function makeUser(): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId('UID-C');
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/FooterValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/FooterValueResolverTest.php
@@ -25,8 +25,7 @@ final class FooterValueResolverTest extends TestCase
 
     private function makeUser(string $email = 'user@example.com', string $uid = 'UID-1'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail($email);
+        $u = new Subscriber($email);
         $u->setUniqueId($uid);
         return $u;
     }
@@ -84,7 +83,7 @@ final class FooterValueResolverTest extends TestCase
             user: $this->makeUser(),
             format: OutputFormat::Text,
             messagePrecacheDto: $dto,
-            forwardedBy: (new Subscriber())->setEmail('fwd@example.com'),
+            forwardedBy: (new Subscriber('fwd@example.com')),
         );
         $this->assertSame(stripslashes($raw), $resolver($ctx));
     }
@@ -100,7 +99,7 @@ final class FooterValueResolverTest extends TestCase
             user: $this->makeUser(),
             format: OutputFormat::Html,
             messagePrecacheDto: $this->makeDto('TF', 'HF', 'Alt'),
-            forwardedBy: (new Subscriber())->setEmail('fwd@example.com'),
+            forwardedBy: (new Subscriber('fwd@example.com')),
         );
 
         $this->assertSame('Forward footer set by config', $resolver($ctx));
@@ -117,7 +116,7 @@ final class FooterValueResolverTest extends TestCase
             user: $this->makeUser(),
             format: OutputFormat::Html,
             messagePrecacheDto: $this->makeDto('TF', 'HF', 'Alt'),
-            forwardedBy: (new Subscriber())->setEmail('fwd@example.com'),
+            forwardedBy: (new Subscriber('fwd@example.com')),
         );
 
         $this->assertSame('', $resolver($ctx));

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/ForwardMessageIdValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/ForwardMessageIdValueResolverTest.php
@@ -27,8 +27,7 @@ final class ForwardMessageIdValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'U-FWD'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/ForwardUrlValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/ForwardUrlValueResolverTest.php
@@ -24,8 +24,7 @@ final class ForwardUrlValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'U1'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/ForwardValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/ForwardValueResolverTest.php
@@ -27,8 +27,7 @@ final class ForwardValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'UID-F'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/JumpoffUrlValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/JumpoffUrlValueResolverTest.php
@@ -27,8 +27,7 @@ final class JumpoffUrlValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'UID-JOU'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/JumpoffValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/JumpoffValueResolverTest.php
@@ -27,8 +27,7 @@ final class JumpoffValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'UID-JO'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/ListsValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/ListsValueResolverTest.php
@@ -26,8 +26,7 @@ final class ListsValueResolverTest extends TestCase
 
     private function makeUser(): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId('UID-L');
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/PreferencesUrlValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/PreferencesUrlValueResolverTest.php
@@ -24,8 +24,7 @@ final class PreferencesUrlValueResolverTest extends TestCase
 
     private function makeUser(): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId('UID-PREF');
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/PreferencesValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/PreferencesValueResolverTest.php
@@ -27,8 +27,7 @@ final class PreferencesValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'UID-PREV'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/SignatureValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/SignatureValueResolverTest.php
@@ -24,8 +24,7 @@ final class SignatureValueResolverTest extends TestCase
 
     private function makeUser(): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId('UID-SIG');
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/SubscribeUrlValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/SubscribeUrlValueResolverTest.php
@@ -24,8 +24,7 @@ final class SubscribeUrlValueResolverTest extends TestCase
 
     private function makeUser(): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId('UID-SUB');
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/SubscribeValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/SubscribeValueResolverTest.php
@@ -27,8 +27,7 @@ final class SubscribeValueResolverTest extends TestCase
 
     private function makeUser(): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId('UID-SV');
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/UnsubscribeUrlValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/UnsubscribeUrlValueResolverTest.php
@@ -27,8 +27,7 @@ final class UnsubscribeUrlValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'UID-UNSUB'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/UnsubscribeValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/UnsubscribeValueResolverTest.php
@@ -30,8 +30,7 @@ final class UnsubscribeValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'UID-U'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }
@@ -120,7 +119,7 @@ final class UnsubscribeValueResolverTest extends TestCase
             format: OutputFormat::Html,
             messagePrecacheDto: null,
             locale: 'en',
-            forwardedBy: (new Subscriber())->setEmail('someone@example.com'),
+            forwardedBy: (new Subscriber('someone@example.com')),
         );
 
         $resolver = new UnsubscribeValueResolver($this->config, $this->urlBuilder, $this->translator);

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/UserDataSupportingResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/UserDataSupportingResolverTest.php
@@ -24,8 +24,7 @@ final class UserDataSupportingResolverTest extends TestCase
     private function makeCtx(Subscriber $user = null): PlaceholderContext
     {
         $u = $user ?? (function () {
-            $s = new Subscriber();
-            $s->setEmail('user@example.com');
+            $s = new Subscriber('user@example.com');
             $s->setUniqueId('UID-X');
             // Ensure the entity has a non-null ID for repository lookup
             $rp = new \ReflectionProperty(Subscriber::class, 'id');

--- a/tests/Unit/Domain/Configuration/Service/Placeholder/UserTrackValueResolverTest.php
+++ b/tests/Unit/Domain/Configuration/Service/Placeholder/UserTrackValueResolverTest.php
@@ -24,8 +24,7 @@ final class UserTrackValueResolverTest extends TestCase
 
     private function makeUser(string $uid = 'U-42'): Subscriber
     {
-        $u = new Subscriber();
-        $u->setEmail('user@example.com');
+        $u = new Subscriber('user@example.com');
         $u->setUniqueId($uid);
         return $u;
     }

--- a/tests/Unit/Domain/Identity/Service/AdminCopyEmailSenderTest.php
+++ b/tests/Unit/Domain/Identity/Service/AdminCopyEmailSenderTest.php
@@ -59,8 +59,7 @@ class AdminCopyEmailSenderTest extends TestCase
         $systemEmailBuilder->expects(self::exactly(count($emails)))
             ->method('buildSystemEmail')
             ->with(self::callback(function (MessagePrecacheDto $data): bool {
-                return $data->to !== null
-                    && str_starts_with($data->subject, 'phpList ')
+                return str_starts_with($data->subject, 'phpList ')
                     && $data->content === 'Hello Admin';
             }))
             ->willReturn(new Email());
@@ -127,7 +126,7 @@ class AdminCopyEmailSenderTest extends TestCase
         $systemEmailBuilder->expects(self::exactly(count($expectedRecipients)))
             ->method('buildSystemEmail')
             ->with(self::callback(function (MessagePrecacheDto $data): bool {
-                return $data->to !== null && str_starts_with($data->subject, 'phpList ');
+                return str_starts_with($data->subject, 'phpList ');
             }))
             ->willReturn(new Email());
 

--- a/tests/Unit/Domain/Identity/Service/AdminNotifierTest.php
+++ b/tests/Unit/Domain/Identity/Service/AdminNotifierTest.php
@@ -33,8 +33,7 @@ final class AdminNotifierTest extends TestCase
         $campaign = $this->createMock(Message::class);
         $campaign->method('getId')->willReturn(42);
 
-        $subscriber = new Subscriber();
-        $subscriber->setEmail('john@example.com');
+        $subscriber = new Subscriber('john@example.com');
 
         $friendEmail = 'friend@example.com';
         $lists = [new SubscriberList()];
@@ -105,8 +104,7 @@ final class AdminNotifierTest extends TestCase
         $campaign = $this->createMock(Message::class);
         $campaign->method('getId')->willReturn(777);
 
-        $subscriber = new Subscriber();
-        $subscriber->setEmail('alice@example.com');
+        $subscriber = new Subscriber('alice@example.com');
 
         $friendEmail = 'bob@example.net';
         $lists = [new SubscriberList(), new SubscriberList()];

--- a/tests/Unit/Domain/Messaging/Model/SubscriberListTest.php
+++ b/tests/Unit/Domain/Messaging/Model/SubscriberListTest.php
@@ -181,7 +181,7 @@ class SubscriberListTest extends TestCase
 
     public function testSetSubscribersSetsSubscribers(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
         $subscription = new Subscription();
         $subscription->setSubscriber($subscriber);
 

--- a/tests/Unit/Domain/Messaging/Service/AttachmentDownloadServiceTest.php
+++ b/tests/Unit/Domain/Messaging/Service/AttachmentDownloadServiceTest.php
@@ -65,7 +65,10 @@ final class AttachmentDownloadServiceTest extends TestCase
     public function testReturnsDownloadableWithExplicitMimeType(): void
     {
         $subscriberRepo = $this->createMock(SubscriberRepository::class);
-        $subscriberRepo->method('findOneByEmail')->with('user@example.com')->willReturn(new Subscriber());
+        $subscriberRepo
+            ->method('findOneByEmail')
+            ->with('user@example.com')
+            ->willReturn(new Subscriber('user@example.com'));
         $service = new AttachmentDownloadService($subscriberRepo, $this->tempDir);
 
         $filename = 'doc.pdf';
@@ -87,7 +90,10 @@ final class AttachmentDownloadServiceTest extends TestCase
     public function testGuessesMimeTypeAndProvidesStream(): void
     {
         $subscriberRepo = $this->createMock(SubscriberRepository::class);
-        $subscriberRepo->method('findOneByEmail')->with('user@example.com')->willReturn(new Subscriber());
+        $subscriberRepo
+            ->method('findOneByEmail')
+            ->with('user@example.com')
+            ->willReturn(new Subscriber('user@example.com'));
         $service = new AttachmentDownloadService($subscriberRepo, $this->tempDir);
 
         $filename = 'note.txt';

--- a/tests/Unit/Domain/Messaging/Service/Builder/EmailBuilderTest.php
+++ b/tests/Unit/Domain/Messaging/Service/Builder/EmailBuilderTest.php
@@ -105,13 +105,12 @@ class EmailBuilderTest extends TestCase
     {
         $this->eventLogManager->expects($this->once())->method('log');
         $dto = new MessagePrecacheDto();
-        $dto->to = null;
         $dto->subject = 'Subj';
         $dto->content = 'Body';
         $dto->fromEmail = 'from@example.com';
 
         $builder = $this->makeBuilder();
-        $result = $builder->buildCampaignEmail(messageId: 1, data: $dto);
+        $result = $builder->buildCampaignEmail(messageId: 1, data: $dto, toEmail: '');
         $this->assertNull($result);
     }
 
@@ -119,12 +118,11 @@ class EmailBuilderTest extends TestCase
     {
         $this->eventLogManager->expects($this->once())->method('log');
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->content = 'Body';
         $dto->fromEmail = 'from@example.com';
 
         $builder = $this->makeBuilder();
-        $result = $builder->buildCampaignEmail(messageId: 1, data: $dto);
+        $result = $builder->buildCampaignEmail(messageId: 1, data: $dto, toEmail: 'user@example.com');
         $this->assertNull($result);
     }
 
@@ -149,13 +147,12 @@ class EmailBuilderTest extends TestCase
             ->method('addHistory');
 
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->subject = 'Hello';
         $dto->content = 'B';
         $dto->fromEmail = 'from@example.com';
 
         $builder = $this->makeBuilder();
-        $result = $builder->buildCampaignEmail(messageId: 5, data: $dto);
+        $result = $builder->buildCampaignEmail(messageId: 5, data: $dto, toEmail: 'user@example.com');
         $this->assertNull($result);
     }
 
@@ -165,7 +162,6 @@ class EmailBuilderTest extends TestCase
             ->method('isEmailBlacklisted')
             ->willReturn(false);
         $dto = new MessagePrecacheDto();
-        $dto->to = 'real@example.com';
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
         $dto->fromEmail = 'from@example.com';
@@ -191,6 +187,7 @@ class EmailBuilderTest extends TestCase
         [$email, $sentAs] = $builder->buildCampaignEmail(
             messageId: 777,
             data: $dto,
+            toEmail: 'real@example.com',
             skipBlacklistCheck: false,
             inBlast: true,
             htmlPref: false,
@@ -221,7 +218,6 @@ class EmailBuilderTest extends TestCase
 
         $this->blacklistRepository->method('isEmailBlacklisted')->willReturn(false);
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
         $dto->fromEmail = 'from@example.com';
@@ -237,7 +233,12 @@ class EmailBuilderTest extends TestCase
             ->willReturn(true);
 
         $builder = $this->makeBuilder(devVersion: false, devEmail: null);
-        [$email, $sentAs] = $builder->buildCampaignEmail(messageId: 9, data: $dto, htmlPref: true);
+        [$email, $sentAs] = $builder->buildCampaignEmail(
+            messageId: 9,
+            data: $dto,
+            htmlPref: true,
+            toEmail: 'user@example.com',
+        );
 
         $this->assertSame(OutputFormat::Text, $sentAs);
         $this->assertSame('TEXT', $email->getTextBody());
@@ -251,7 +252,6 @@ class EmailBuilderTest extends TestCase
             ->method('isEmailBlacklisted')
             ->willReturn(false);
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
         $dto->fromEmail = 'from@example.com';
@@ -272,7 +272,12 @@ class EmailBuilderTest extends TestCase
             ->willReturn(true);
 
         $builder = $this->makeBuilder(devVersion: false, devEmail: null);
-        [$email, $sentAs] = $builder->buildCampaignEmail(messageId: 42, data: $dto, htmlPref: true);
+        [$email, $sentAs] = $builder->buildCampaignEmail(
+            messageId: 42,
+            data: $dto,
+            htmlPref: true,
+            toEmail: 'user@example.com',
+        );
 
         $this->assertSame(OutputFormat::Pdf, $sentAs);
         $this->assertCount(1, $email->getAttachments());
@@ -284,7 +289,6 @@ class EmailBuilderTest extends TestCase
             ->method('isEmailBlacklisted')
             ->willReturn(false);
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
         $dto->fromEmail = 'from@example.com';
@@ -303,7 +307,12 @@ class EmailBuilderTest extends TestCase
             ->method('createPdfBytes');
 
         $builder = $this->makeBuilder(devVersion: false, devEmail: null);
-        [$email, $sentAs] = $builder->buildCampaignEmail(messageId: 43, data: $dto, htmlPref: false);
+        [$email, $sentAs] = $builder->buildCampaignEmail(
+            messageId: 43,
+            data: $dto,
+            htmlPref: false,
+            toEmail: 'user@example.com',
+        );
 
         $this->assertSame(OutputFormat::Text, $sentAs);
         $this->assertSame('TEXT', $email->getTextBody());
@@ -318,7 +327,6 @@ class EmailBuilderTest extends TestCase
 
         // explicit reply-to
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
         $dto->fromEmail = 'from@example.com';
@@ -332,12 +340,11 @@ class EmailBuilderTest extends TestCase
             ->willReturn(true);
 
         $builder = $this->makeBuilder(devVersion: false, devEmail: null);
-        [$email] = $builder->buildCampaignEmail(messageId: 50, data: $dto);
+        [$email] = $builder->buildCampaignEmail(messageId: 50, data: $dto, toEmail: 'user@example.com');
         $this->assertSame('reply@example.com', $email->getReplyTo()[0]->getAddress());
 
         // no reply-to, but test mail -> uses AdminAddress
         $dto2 = new MessagePrecacheDto();
-        $dto2->to = 'user@example.com';
         $dto2->subject = 'Subject';
         $dto2->content = 'TEXT';
         $dto2->fromEmail = 'from@example.com';
@@ -350,7 +357,12 @@ class EmailBuilderTest extends TestCase
             ->with('(test)')
             ->willReturn('(test)');
 
-        [$email2] = $builder->buildCampaignEmail(messageId: 51, data: $dto2, isTestMail: true);
+        [$email2] = $builder->buildCampaignEmail(
+            messageId: 51,
+            data: $dto2,
+            toEmail: 'user@example.com',
+            isTestMail: true,
+        );
         $this->assertSame('admin@example.com', $email2->getReplyTo()[0]->getAddress());
         $this->assertStringStartsWith('(test) ', $email2->getSubject());
     }
@@ -395,7 +407,6 @@ class EmailBuilderTest extends TestCase
             ->method('isEmailBlacklisted')
             ->willReturn(false);
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
         $dto->fromEmail = 'from@example.com';
@@ -413,6 +424,6 @@ class EmailBuilderTest extends TestCase
         $builder = $this->makeBuilder(devVersion: false, devEmail: null);
 
         $this->expectException(AttachmentException::class);
-        $builder->buildCampaignEmail(messageId: 60, data: $dto, htmlPref: true);
+        $builder->buildCampaignEmail(messageId: 60, data: $dto, htmlPref: true, toEmail: 'user@example.com');
     }
 }

--- a/tests/Unit/Domain/Messaging/Service/Builder/EmailBuilderTest.php
+++ b/tests/Unit/Domain/Messaging/Service/Builder/EmailBuilderTest.php
@@ -161,6 +161,7 @@ class EmailBuilderTest extends TestCase
         $this->blacklistRepository
             ->method('isEmailBlacklisted')
             ->willReturn(false);
+        $this->subscriberRepository->method('findOneByEmail')->willReturn(new Subscriber('user@example.com'));
         $dto = new MessagePrecacheDto();
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
@@ -215,7 +216,7 @@ class EmailBuilderTest extends TestCase
                 [ConfigOption::AdminAddress, 'admin@example.com'],
                 [ConfigOption::AlwaysSendTextDomains, ''],
             ]);
-
+        $this->subscriberRepository->method('findOneByEmail')->willReturn(new Subscriber('user@example.com'));
         $this->blacklistRepository->method('isEmailBlacklisted')->willReturn(false);
         $dto = new MessagePrecacheDto();
         $dto->subject = 'Subject';
@@ -236,8 +237,8 @@ class EmailBuilderTest extends TestCase
         [$email, $sentAs] = $builder->buildCampaignEmail(
             messageId: 9,
             data: $dto,
-            htmlPref: true,
             toEmail: 'user@example.com',
+            htmlPref: true,
         );
 
         $this->assertSame(OutputFormat::Text, $sentAs);
@@ -251,6 +252,7 @@ class EmailBuilderTest extends TestCase
         $this->blacklistRepository
             ->method('isEmailBlacklisted')
             ->willReturn(false);
+        $this->subscriberRepository->method('findOneByEmail')->willReturn(new Subscriber('user@example.com'));
         $dto = new MessagePrecacheDto();
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
@@ -275,8 +277,8 @@ class EmailBuilderTest extends TestCase
         [$email, $sentAs] = $builder->buildCampaignEmail(
             messageId: 42,
             data: $dto,
-            htmlPref: true,
             toEmail: 'user@example.com',
+            htmlPref: true,
         );
 
         $this->assertSame(OutputFormat::Pdf, $sentAs);
@@ -288,6 +290,7 @@ class EmailBuilderTest extends TestCase
         $this->blacklistRepository
             ->method('isEmailBlacklisted')
             ->willReturn(false);
+        $this->subscriberRepository->method('findOneByEmail')->willReturn(new Subscriber('user@example.com'));
         $dto = new MessagePrecacheDto();
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
@@ -310,8 +313,8 @@ class EmailBuilderTest extends TestCase
         [$email, $sentAs] = $builder->buildCampaignEmail(
             messageId: 43,
             data: $dto,
-            htmlPref: false,
             toEmail: 'user@example.com',
+            htmlPref: false,
         );
 
         $this->assertSame(OutputFormat::Text, $sentAs);
@@ -324,6 +327,7 @@ class EmailBuilderTest extends TestCase
         $this->blacklistRepository
             ->method('isEmailBlacklisted')
             ->willReturn(false);
+        $this->subscriberRepository->method('findOneByEmail')->willReturn(new Subscriber('user@example.com'));
 
         // explicit reply-to
         $dto = new MessagePrecacheDto();
@@ -406,6 +410,8 @@ class EmailBuilderTest extends TestCase
         $this->blacklistRepository
             ->method('isEmailBlacklisted')
             ->willReturn(false);
+        $this->subscriberRepository->method('findOneByEmail')->willReturn(new Subscriber('user@example.com'));
+
         $dto = new MessagePrecacheDto();
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';

--- a/tests/Unit/Domain/Messaging/Service/Builder/ForwardEmailBuilderTest.php
+++ b/tests/Unit/Domain/Messaging/Service/Builder/ForwardEmailBuilderTest.php
@@ -147,7 +147,7 @@ class ForwardEmailBuilderTest extends TestCase
         [$email, $sentAs] = $builder->buildForwardEmail(
             messageId: 99,
             friendEmail: $friendEmail,
-            forwardedBy: new Subscriber(),
+            forwardedBy: new Subscriber('alice@example.com'),
             data: $dto,
             htmlPref: true,
             fromName: $fromName,
@@ -186,7 +186,7 @@ class ForwardEmailBuilderTest extends TestCase
         $builder->buildForwardEmail(
             messageId: 1,
             friendEmail: $friend,
-            forwardedBy: new Subscriber(),
+            forwardedBy: new Subscriber('alice@example.com'),
             data: $dto,
             htmlPref: false,
             fromName: 'X',
@@ -216,7 +216,7 @@ class ForwardEmailBuilderTest extends TestCase
         $result = $builder->buildForwardEmail(
             messageId: 2,
             friendEmail: 'friend@example.com',
-            forwardedBy: new Subscriber(),
+            forwardedBy: new Subscriber('alice@example.com'),
             data: $dto,
             htmlPref: false,
             fromName: 'From',

--- a/tests/Unit/Domain/Messaging/Service/Builder/SystemEmailBuilderTest.php
+++ b/tests/Unit/Domain/Messaging/Service/Builder/SystemEmailBuilderTest.php
@@ -82,12 +82,11 @@ class SystemEmailBuilderTest extends TestCase
     {
         $this->eventLogManager->expects($this->once())->method('log');
         $dto = new MessagePrecacheDto();
-        $dto->to = null;
         $dto->subject = 'Subj';
         $dto->content = 'Body';
 
         $builder = $this->makeBuilder();
-        $result = $builder->buildCampaignEmail(messageId: 1, data: $dto);
+        $result = $builder->buildCampaignEmail(messageId: 1, data: $dto, toEmail: '');
         $this->assertNull($result);
     }
 
@@ -95,11 +94,10 @@ class SystemEmailBuilderTest extends TestCase
     {
         $this->eventLogManager->expects($this->once())->method('log');
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->content = 'Body';
 
         $builder = $this->makeBuilder();
-        $result = $builder->buildCampaignEmail(messageId: 1, data: $dto);
+        $result = $builder->buildCampaignEmail(messageId: 1, data: $dto, toEmail: 'user@example.com');
         $this->assertNull($result);
     }
 
@@ -123,12 +121,11 @@ class SystemEmailBuilderTest extends TestCase
             ->method('addHistory');
 
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->subject = 'Hello';
         $dto->content = 'B';
 
         $builder = $this->makeBuilder();
-        $result = $builder->buildCampaignEmail(messageId: 5, data: $dto);
+        $result = $builder->buildCampaignEmail(messageId: 5, data: $dto, toEmail: 'user@example.com');
         $this->assertNull($result);
     }
 
@@ -138,7 +135,6 @@ class SystemEmailBuilderTest extends TestCase
             ->method('isEmailBlacklisted')
             ->willReturn(false);
         $dto = new MessagePrecacheDto();
-        $dto->to = 'real@example.com';
         $dto->subject = 'Subject';
         $dto->content = 'TEXT';
 
@@ -164,6 +160,7 @@ class SystemEmailBuilderTest extends TestCase
             messageId: 777,
             data: $dto,
             skipBlacklistCheck: false,
+            toEmail: 'real@example.com'
         );
 
         $this->assertNotNull($email);

--- a/tests/Unit/Domain/Messaging/Service/Constructor/CampaignMailContentBuilderTest.php
+++ b/tests/Unit/Domain/Messaging/Service/Constructor/CampaignMailContentBuilderTest.php
@@ -12,7 +12,6 @@ use PhpList\Core\Domain\Configuration\Service\Manager\EventLogManager;
 use PhpList\Core\Domain\Configuration\Service\Provider\ConfigProvider;
 use PhpList\Core\Domain\Configuration\Service\MessagePlaceholderProcessor;
 use PhpList\Core\Domain\Messaging\Exception\RemotePageFetchException;
-use PhpList\Core\Domain\Messaging\Exception\SubscriberNotFoundException;
 use PhpList\Core\Domain\Messaging\Model\Dto\MessagePrecacheDto;
 use PhpList\Core\Domain\Messaging\Service\Constructor\CampaignMailContentBuilder;
 use PhpList\Core\Domain\Subscription\Model\Subscriber;
@@ -71,18 +70,6 @@ class CampaignMailContentBuilderTest extends TestCase
         );
     }
 
-    public function testThrowsWhenSubscriberNotFound(): void
-    {
-        $dto = new MessagePrecacheDto();
-        $dto->content = 'Hello';
-
-        $this->subscriberRepository->method('findOneByEmail')->willReturn(null);
-
-        $builder = $this->makeBuilder();
-        $this->expectException(SubscriberNotFoundException::class);
-        $builder($dto, 'missing@example.com', 10);
-    }
-
     public function testBuildsHtmlFormattedGeneratesTextViaHtml2Text(): void
     {
         $subscriber = $this->getMockBuilder(Subscriber::class)
@@ -113,7 +100,7 @@ class CampaignMailContentBuilderTest extends TestCase
             ->willReturn('Hi');
 
         $builder = $this->makeBuilder();
-        [$html, $text] = $builder($dto, 'user@example.com', 5);
+        [$html, $text] = $builder($dto, $subscriber, 5);
 
         $this->assertSame('Hi', $text);
         $this->assertStringContainsString('<b>Hi</b>', $html);
@@ -155,7 +142,7 @@ class CampaignMailContentBuilderTest extends TestCase
             ->willReturn('<p>Hello world</p>');
 
         $builder = $this->makeBuilder();
-        [$html, $text] = $builder($dto, 'user@example.com', 7);
+        [$html, $text] = $builder($dto, $subscriber, 7);
 
         $this->assertSame('Hello world', $text);
         $this->assertStringContainsString('<p>Hello world</p>', $html);
@@ -200,7 +187,7 @@ class CampaignMailContentBuilderTest extends TestCase
             );
 
         $builder = $this->makeBuilder();
-        [$html] = $builder($dto, 'user@example.com', 11);
+        [$html] = $builder($dto, $subscriber, 11);
         $this->assertStringContainsString('<!--https://example.com/path--><div>REMOTE</div>', $html);
 
         // Failure path (empty content) should log and throw
@@ -213,7 +200,7 @@ class CampaignMailContentBuilderTest extends TestCase
             ->method('log');
 
         $this->expectException(RemotePageFetchException::class);
-        $builder($dto2, 'user@example.com', 12);
+        $builder($dto2, $subscriber, 12);
     }
 
     public function testTemplatePreventsDefaultStyleInjection(): void
@@ -242,7 +229,7 @@ class CampaignMailContentBuilderTest extends TestCase
         $dto->template = '<html><head><title>T</title></head><body>BEFORE[CONTENT]AFTER</body></html>';
 
         $builder = $this->makeBuilder();
-        [$html, $text] = $builder($dto, 'user@example.com', 2);
+        [$html, $text] = $builder($dto, $subscriber, 2);
 
         $this->assertStringContainsString('BEFORE<p>Inner</p>AFTER', $html);
         $this->assertStringNotContainsString(

--- a/tests/Unit/Domain/Messaging/Service/Constructor/CampaignMailContentBuilderTest.php
+++ b/tests/Unit/Domain/Messaging/Service/Constructor/CampaignMailContentBuilderTest.php
@@ -74,14 +74,13 @@ class CampaignMailContentBuilderTest extends TestCase
     public function testThrowsWhenSubscriberNotFound(): void
     {
         $dto = new MessagePrecacheDto();
-        $dto->to = 'missing@example.com';
         $dto->content = 'Hello';
 
         $this->subscriberRepository->method('findOneByEmail')->willReturn(null);
 
         $builder = $this->makeBuilder();
         $this->expectException(SubscriberNotFoundException::class);
-        $builder($dto, 10);
+        $builder($dto, 'missing@example.com', 10);
     }
 
     public function testBuildsHtmlFormattedGeneratesTextViaHtml2Text(): void
@@ -105,7 +104,6 @@ class CampaignMailContentBuilderTest extends TestCase
             );
 
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->content = '<b>Hi</b>';
         $dto->htmlFormatted = true;
 
@@ -115,7 +113,7 @@ class CampaignMailContentBuilderTest extends TestCase
             ->willReturn('Hi');
 
         $builder = $this->makeBuilder();
-        [$html, $text] = $builder($dto, 5);
+        [$html, $text] = $builder($dto, 'user@example.com', 5);
 
         $this->assertSame('Hi', $text);
         $this->assertStringContainsString('<b>Hi</b>', $html);
@@ -148,7 +146,6 @@ class CampaignMailContentBuilderTest extends TestCase
             );
 
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->content = 'Hello world';
         $dto->htmlFormatted = false;
 
@@ -158,7 +155,7 @@ class CampaignMailContentBuilderTest extends TestCase
             ->willReturn('<p>Hello world</p>');
 
         $builder = $this->makeBuilder();
-        [$html, $text] = $builder($dto, 7);
+        [$html, $text] = $builder($dto, 'user@example.com', 7);
 
         $this->assertSame('Hello world', $text);
         $this->assertStringContainsString('<p>Hello world</p>', $html);
@@ -183,7 +180,6 @@ class CampaignMailContentBuilderTest extends TestCase
 
         // Success path replacement
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->content = 'Intro [URL:example.com/path] End';
         $dto->userSpecificUrl = true;
 
@@ -204,12 +200,11 @@ class CampaignMailContentBuilderTest extends TestCase
             );
 
         $builder = $this->makeBuilder();
-        [$html] = $builder($dto, 11);
+        [$html] = $builder($dto, 'user@example.com', 11);
         $this->assertStringContainsString('<!--https://example.com/path--><div>REMOTE</div>', $html);
 
         // Failure path (empty content) should log and throw
         $dto2 = new MessagePrecacheDto();
-        $dto2->to = 'user@example.com';
         $dto2->content = 'Again [URL:example.com/empty] test';
         $dto2->userSpecificUrl = true;
 
@@ -218,7 +213,7 @@ class CampaignMailContentBuilderTest extends TestCase
             ->method('log');
 
         $this->expectException(RemotePageFetchException::class);
-        $builder($dto2, 12);
+        $builder($dto2, 'user@example.com', 12);
     }
 
     public function testTemplatePreventsDefaultStyleInjection(): void
@@ -242,13 +237,12 @@ class CampaignMailContentBuilderTest extends TestCase
             );
 
         $dto = new MessagePrecacheDto();
-        $dto->to = 'user@example.com';
         $dto->content = '<p>Inner</p>';
         $dto->htmlFormatted = true;
         $dto->template = '<html><head><title>T</title></head><body>BEFORE[CONTENT]AFTER</body></html>';
 
         $builder = $this->makeBuilder();
-        [$html, $text] = $builder($dto, 2);
+        [$html, $text] = $builder($dto, 'user@example.com', 2);
 
         $this->assertStringContainsString('BEFORE<p>Inner</p>AFTER', $html);
         $this->assertStringNotContainsString(

--- a/tests/Unit/Domain/Messaging/Service/ForwardContentServiceTest.php
+++ b/tests/Unit/Domain/Messaging/Service/ForwardContentServiceTest.php
@@ -42,7 +42,7 @@ class ForwardContentServiceTest extends TestCase
 
         $campaign = $this->createMock(Message::class);
         $campaign->method('getId')->willReturn(10);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
 
         $this->cache
             ->expects(self::once())
@@ -76,7 +76,7 @@ class ForwardContentServiceTest extends TestCase
 
         $campaign = $this->createMock(Message::class);
         $campaign->method('getId')->willReturn(42);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
         $subscriber->setHtmlEmail(true);
 
         $cached = new MessagePrecacheDto();

--- a/tests/Unit/Domain/Messaging/Service/ForwardDeliveryServiceTest.php
+++ b/tests/Unit/Domain/Messaging/Service/ForwardDeliveryServiceTest.php
@@ -73,7 +73,7 @@ class ForwardDeliveryServiceTest extends TestCase
         );
 
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
         $friendEmail = 'friend@example.test';
 
         $this->forwardManager->expects(self::once())
@@ -97,7 +97,7 @@ class ForwardDeliveryServiceTest extends TestCase
         );
 
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
         $friendEmail = 'friend@example.test';
 
         $this->forwardManager->expects(self::once())

--- a/tests/Unit/Domain/Messaging/Service/ForwardingGuardTest.php
+++ b/tests/Unit/Domain/Messaging/Service/ForwardingGuardTest.php
@@ -43,7 +43,7 @@ class ForwardingGuardTest extends TestCase
 
         $uid = 'abc';
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
 
         $this->subscriberRepo->method('findOneByUniqueId')->with($uid)->willReturn($subscriber);
         $this->userMessageRepo->method('findByUserAndMessage')->willReturn(
@@ -81,7 +81,7 @@ class ForwardingGuardTest extends TestCase
             forwardEmailPeriod: '1 day',
         );
 
-        $this->subscriberRepo->method('findOneByUniqueId')->willReturn(new Subscriber());
+        $this->subscriberRepo->method('findOneByUniqueId')->willReturn(new Subscriber('alice@example.com'));
         $this->userMessageRepo->method('findByUserAndMessage')->willReturn(null);
 
         $this->expectException(MessageNotReceivedException::class);
@@ -98,7 +98,7 @@ class ForwardingGuardTest extends TestCase
             forwardEmailPeriod: '1 day',
         );
 
-        $this->subscriberRepo->method('findOneByUniqueId')->willReturn(new Subscriber());
+        $this->subscriberRepo->method('findOneByUniqueId')->willReturn(new Subscriber('alice@example.com'));
         $this->userMessageRepo->method('findByUserAndMessage')->willReturn($this->createMock(UserMessage::class));
         $this->forwardRepo->method('getCountByUserSince')->willReturn(2);
 

--- a/tests/Unit/Domain/Messaging/Service/Manager/BounceManagerTest.php
+++ b/tests/Unit/Domain/Messaging/Service/Manager/BounceManagerTest.php
@@ -179,7 +179,7 @@ class BounceManagerTest extends TestCase
 
     public function testGetUserMessageHistoryWithBouncesDelegates(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
         $expected = [];
         $this->userMessageBounceRepository->expects($this->once())
             ->method('getUserMessageHistoryWithBounces')

--- a/tests/Unit/Domain/Messaging/Service/MessageForwardServiceTest.php
+++ b/tests/Unit/Domain/Messaging/Service/MessageForwardServiceTest.php
@@ -75,7 +75,7 @@ class MessageForwardServiceTest extends TestCase
     {
         $service = $this->createService();
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
 
         $this->loader->expects(self::once())
             ->method('__invoke')
@@ -114,7 +114,7 @@ class MessageForwardServiceTest extends TestCase
     {
         $service = $this->createService();
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
 
         $this->loader->method('__invoke')->willReturn(['ok' => true]);
         $this->guard->method('assertCanForward')->willReturn($subscriber);
@@ -142,7 +142,7 @@ class MessageForwardServiceTest extends TestCase
     {
         $service = $this->createService();
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
 
         $this->loader->method('__invoke')->willReturn(['ok' => true]);
         $this->guard->method('assertCanForward')->willReturn($subscriber);
@@ -181,7 +181,7 @@ class MessageForwardServiceTest extends TestCase
     {
         $service = $this->createService();
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
 
         $this->loader->method('__invoke')->willReturn(['ok' => true]);
         $this->guard->method('assertCanForward')->willReturn($subscriber);
@@ -214,7 +214,7 @@ class MessageForwardServiceTest extends TestCase
     {
         $service = $this->createService();
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
 
         $this->loader->method('__invoke')->willReturn(['ok' => true]);
         $this->guard->method('assertCanForward')->willReturn($subscriber);
@@ -245,7 +245,7 @@ class MessageForwardServiceTest extends TestCase
     {
         $service = $this->createService();
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
 
         $this->loader->method('__invoke')->willReturn(['data' => true]);
         $this->guard->method('assertCanForward')->willReturn($subscriber);
@@ -272,7 +272,7 @@ class MessageForwardServiceTest extends TestCase
     {
         $service = $this->createService();
         $campaign = $this->createMock(Message::class);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('alice@example.com');
 
         $this->loader->method('__invoke')->willReturn(['ok' => 1]);
         $this->guard->method('assertCanForward')->willReturn($subscriber);

--- a/tests/Unit/Domain/Subscription/Model/SubscriberTest.php
+++ b/tests/Unit/Domain/Subscription/Model/SubscriberTest.php
@@ -28,7 +28,7 @@ class SubscriberTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subscriber = new Subscriber();
+        $this->subscriber = new Subscriber('test@example.com');
     }
 
     public function testIsDomainModel(): void

--- a/tests/Unit/Domain/Subscription/Model/SubscriberTest.php
+++ b/tests/Unit/Domain/Subscription/Model/SubscriberTest.php
@@ -28,7 +28,7 @@ class SubscriberTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subscriber = new Subscriber('test@example.com');
+        $this->subscriber = new Subscriber('');
     }
 
     public function testIsDomainModel(): void

--- a/tests/Unit/Domain/Subscription/Model/SubscriptionTest.php
+++ b/tests/Unit/Domain/Subscription/Model/SubscriptionTest.php
@@ -42,7 +42,7 @@ class SubscriptionTest extends TestCase
 
     public function testSetSubscriberSetsSubscriber(): void
     {
-        $model = new Subscriber();
+        $model = new Subscriber('test@example.com');
         $this->subject->setSubscriber($model);
 
         self::assertSame($model, $this->subject->getSubscriber());

--- a/tests/Unit/Domain/Subscription/Service/Manager/SubscriberAttributeManagerTest.php
+++ b/tests/Unit/Domain/Subscription/Service/Manager/SubscriberAttributeManagerTest.php
@@ -22,7 +22,7 @@ class SubscriberAttributeManagerTest extends TestCase
 {
     public function testCreateNewSubscriberAttribute(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('test@example.com');
         $definition = new SubscriberAttributeDefinition();
 
         $subscriberAttrRepo = $this->createMock(SubscriberAttributeValueRepository::class);
@@ -53,7 +53,7 @@ class SubscriberAttributeManagerTest extends TestCase
 
     public function testUpdateExistingSubscriberAttribute(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('test@example.com');
         $definition = new SubscriberAttributeDefinition();
         $existing = new SubscriberAttributeValue($definition, $subscriber);
         $existing->setValue('Old');
@@ -83,7 +83,7 @@ class SubscriberAttributeManagerTest extends TestCase
 
     public function testCreateFailsWhenValueAndDefaultAreNull(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('test@example.com');
         $definition = new SubscriberAttributeDefinition();
 
         $subscriberAttrRepo = $this->createMock(SubscriberAttributeValueRepository::class);
@@ -109,7 +109,10 @@ class SubscriberAttributeManagerTest extends TestCase
         $subscriberAttrRepo = $this->createMock(SubscriberAttributeValueRepository::class);
         $entityManager = $this->createMock(EntityManagerInterface::class);
 
-        $expected = new SubscriberAttributeValue(new SubscriberAttributeDefinition(), new Subscriber());
+        $expected = new SubscriberAttributeValue(
+            new SubscriberAttributeDefinition(),
+            new Subscriber('test@example.com')
+        );
         $subscriberAttrRepo->expects(self::once())
             ->method('findOneBySubscriberIdAndAttributeId')
             ->with(5, 10)

--- a/tests/Unit/Domain/Subscription/Service/Manager/SubscriberBlacklistManagerTest.php
+++ b/tests/Unit/Domain/Subscription/Service/Manager/SubscriberBlacklistManagerTest.php
@@ -130,6 +130,7 @@ class SubscriberBlacklistManagerTest extends TestCase
         $blacklist = $this->createMock(UserBlacklist::class);
         $blacklistData = $this->createMock(UserBlacklistData::class);
         $subscriber = $this->getMockBuilder(Subscriber::class)
+            ->setConstructorArgs(['test@example.com'])
             ->onlyMethods(['setBlacklisted'])
             ->getMock();
 

--- a/tests/Unit/Domain/Subscription/Service/Manager/SubscriptionManagerTest.php
+++ b/tests/Unit/Domain/Subscription/Service/Manager/SubscriptionManagerTest.php
@@ -44,7 +44,7 @@ class SubscriptionManagerTest extends TestCase
     public function testCreateSubscriptionWhenSubscriberExists(): void
     {
         $email = 'test@example.com';
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber($email);
         $list = new SubscriberList();
 
         $this->subscriberRepository->method('findOneBy')->with(['email' => $email])->willReturn($subscriber);
@@ -106,7 +106,7 @@ class SubscriptionManagerTest extends TestCase
     {
         $subscriberList = $this->createMock(SubscriberList::class);
         $subscriberList->method('getId')->willReturn(1);
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('user@example.com');
 
         $this->subscriberRepository
             ->method('getSubscribersBySubscribedListId')

--- a/tests/Unit/Domain/Subscription/Service/Provider/CheckboxGroupValueProviderTest.php
+++ b/tests/Unit/Domain/Subscription/Service/Provider/CheckboxGroupValueProviderTest.php
@@ -40,7 +40,7 @@ class CheckboxGroupValueProviderTest extends TestCase
 
     private function createUserAttr(SubscriberAttributeDefinition $def, ?string $value): SubscriberAttributeValue
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('user@example.com');
         $userAttr = new SubscriberAttributeValue($def, $subscriber);
         $userAttr->setValue($value);
 

--- a/tests/Unit/Domain/Subscription/Service/Provider/SubscriberAttributeChangeSetProviderTest.php
+++ b/tests/Unit/Domain/Subscription/Service/Provider/SubscriberAttributeChangeSetProviderTest.php
@@ -39,7 +39,7 @@ final class SubscriberAttributeChangeSetProviderTest extends TestCase
 
     public function testNoChangesWhenNewAndExistingAreIdenticalCaseInsensitive(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('user@example.com');
         $existing = [
             $this->attr('Name', 'John', $subscriber),
             $this->attr('Age', '30', $subscriber),
@@ -64,7 +64,7 @@ final class SubscriberAttributeChangeSetProviderTest extends TestCase
 
     public function testAddedAttributeAppearsWithNullOldValue(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('user@example.com');
         $existing = [
             $this->attr('Name', 'John', $subscriber),
         ];
@@ -86,7 +86,7 @@ final class SubscriberAttributeChangeSetProviderTest extends TestCase
 
     public function testRemovedAttributeAppearsWithNullNewValue(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('user@example.com');
         $existing = [
             $this->attr('Country', 'US', $subscriber),
         ];
@@ -102,7 +102,7 @@ final class SubscriberAttributeChangeSetProviderTest extends TestCase
 
     public function testChangedAttributeShowsOldAndNewValues(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('user@example.com');
         $existing = [
             $this->attr('Phone', '123', $subscriber),
         ];
@@ -121,7 +121,7 @@ final class SubscriberAttributeChangeSetProviderTest extends TestCase
 
     public function testIgnoredAttributesAreExcluded(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('user@example.com');
         $existing = [
             $this->attr('Password', 'old', $subscriber),
             $this->attr('Modified', 'yesterday', $subscriber),
@@ -147,7 +147,7 @@ final class SubscriberAttributeChangeSetProviderTest extends TestCase
 
     public function testCaseInsensitiveKeyComparisonAndResultLowercasing(): void
     {
-        $subscriber = new Subscriber();
+        $subscriber = new Subscriber('user@example.com');
         $existing = [
             $this->attr('FirstName', 'Ann', $subscriber),
         ];


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Recipient addresses are now passed explicitly throughout the email pipeline for clearer, more reliable message construction and handling.
* **Refactor**
  * Subscriber creation now requires an email at instantiation, enforcing consistent initialization.
* **Bug Fixes**
  * Admin notification filtering relaxed so system notifications are handled more consistently even when recipient info is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Thanks for contributing to phpList!
